### PR TITLE
Adding Base SQL Queries

### DIFF
--- a/SQL-Queries/Demand_PropertyV,  Demand_ChannelV, Demand_SegmentV.sql
+++ b/SQL-Queries/Demand_PropertyV,  Demand_ChannelV, Demand_SegmentV.sql
@@ -1,0 +1,28 @@
+CREATE OR REPLACE VIEW `aparium-dataflow.DemandData.DemandData_PropertyV` AS
+  SELECT *
+FROM (
+  SELECT *,
+         ROW_NUMBER() OVER (PARTITION BY stay_date, property_code ORDER BY snapshot_date DESC) AS rn
+  FROM `aparium-dataflow.DemandData.DemandData_Property`
+)
+WHERE rn = 1;
+
+
+CREATE OR REPLACE VIEW `aparium-dataflow.DemandData.DemandData_SegmentV` AS
+  SELECT *
+FROM (
+  SELECT *,
+         ROW_NUMBER() OVER (PARTITION BY stay_date, property_code ORDER BY snapshot_date DESC) AS rn
+  FROM `aparium-dataflow.DemandData.DemandData_Segment`
+)
+WHERE rn = 1;
+
+
+CREATE OR REPLACE VIEW `aparium-dataflow.DemandData.DemandData_ChannelV` AS
+  SELECT *
+FROM (
+  SELECT *,
+         ROW_NUMBER() OVER (PARTITION BY stay_date, property_code ORDER BY snapshot_date DESC) AS rn
+  FROM `aparium-dataflow.DemandData.DemandData_Channel`
+)
+WHERE rn = 1

--- a/SQL-Queries/Finance Budget_MajorSegmentDailyV + Forecast_MajorSegmentDailyV.sql
+++ b/SQL-Queries/Finance Budget_MajorSegmentDailyV + Forecast_MajorSegmentDailyV.sql
@@ -1,0 +1,294 @@
+
+
+----------------------------------------------------
+-- CREATE Budget + Forcast Major Segment View
+----------------------------------------------------
+
+
+----------------------------------------------------
+-- BUDGET MAJOR SEGMENT
+----------------------------------------------------
+
+
+CREATE OR REPLACE VIEW `devrebel-big-query-database.Finance.Budget_MajorSegmentDailyV` AS
+WITH RankedData AS (
+  -- Get the latest snapshot per property & segment
+  SELECT 
+    *, 
+    ROW_NUMBER() OVER (PARTITION BY property_code, segment_name ORDER BY snapshot_date DESC) AS rn
+  FROM `devrebel-big-query-database.Finance.Finance_Budget`
+  WHERE segment_name IN ( 'Transient Rooms', 'Transient Revenue', 'Group Rooms', 
+                          'Group Revenue', 'Contract Rooms', 'Contract Revenue', 
+                          'Available Rooms', 'Rooms Sold', 'Occupied Rooms', 
+                          'Rooms Revenue', 'Other Rooms Revenue' )
+), 
+FilteredData AS (
+  -- Only keep the latest snapshot per property and segment
+  SELECT * 
+  FROM RankedData 
+  WHERE rn = 1
+), 
+Unpivoted AS (
+  -- Unpivot month columns into a row-based format
+  SELECT 
+    property_code,
+    segment_name,
+    CAST(SUBSTR(finance_period, 3, 2) AS INT64) + 2000 AS fiscal_year,
+    CASE 
+      WHEN month = 'month_01' THEN 1 
+      WHEN month = 'month_02' THEN 2 
+      WHEN month = 'month_03' THEN 3 
+      WHEN month = 'month_04' THEN 4 
+      WHEN month = 'month_05' THEN 5 
+      WHEN month = 'month_06' THEN 6 
+      WHEN month = 'month_07' THEN 7 
+      WHEN month = 'month_08' THEN 8 
+      WHEN month = 'month_09' THEN 9 
+      WHEN month = 'month_10' THEN 10 
+      WHEN month = 'month_11' THEN 11 
+      WHEN month = 'month_12' THEN 12 
+    END AS month_number,
+    value AS month_total
+  FROM FilteredData
+  UNPIVOT (
+    value FOR month IN (
+      month_01, month_02, month_03, month_04, month_05, month_06, 
+      month_07, month_08, month_09, month_10, month_11, month_12
+    )
+  )
+),
+DaysInMonth AS (
+  -- Assign correct number of days per month
+  SELECT 
+    *,
+    CASE 
+      WHEN month_number IN (1, 3, 5, 7, 8, 10, 12) THEN 31
+      WHEN month_number IN (4, 6, 9, 11) THEN 30
+      WHEN month_number = 2 THEN 28
+    END AS days_in_month
+  FROM Unpivoted
+),
+DailyBreakdown AS (
+  -- Distribute values evenly across all days in the month
+  SELECT 
+    property_code,
+    segment_name,
+    month_total,  -- Carrying forward month_total
+    DATE_FROM_UNIX_DATE(UNIX_DATE(DATE(fiscal_year, month_number, 1)) + day_offset) AS stay_date,
+    CASE 
+      WHEN segment_name = 'Rooms Sold' 
+      THEN ROUND(month_total / days_in_month) -- Ensure whole number for "Rooms Sold"
+      ELSE month_total / days_in_month
+    END AS daily_value
+  FROM DaysInMonth,
+  UNNEST(GENERATE_ARRAY(0, days_in_month - 1)) AS day_offset
+),
+SumCheck AS (
+  -- Compute total distributed sum for each property_code, stay_date, and segment
+  SELECT 
+    property_code, 
+    stay_date, 
+    segment_name, 
+    month_total, -- Carrying forward month_total
+    SUM(daily_value) OVER (PARTITION BY property_code, segment_name, EXTRACT(YEAR FROM stay_date), EXTRACT(MONTH FROM stay_date)) AS total_allocated,
+    SUM(CASE WHEN segment_name = 'Rooms Sold' THEN daily_value ELSE 0 END) 
+      OVER (PARTITION BY property_code, segment_name, EXTRACT(YEAR FROM stay_date), EXTRACT(MONTH FROM stay_date)) AS allocated_rooms_sold,
+    daily_value
+  FROM DailyBreakdown
+),
+Adjustment AS (
+  -- Compute the adjustment required for "Rooms Sold"
+  SELECT 
+    property_code, 
+    segment_name, 
+    MAX(stay_date) AS last_stay_date,
+    SUM(daily_value) AS total_allocated,
+    SUM(CASE WHEN segment_name = 'Rooms Sold' THEN daily_value ELSE 0 END) AS allocated_rooms_sold,
+    SUM(CASE WHEN segment_name = 'Rooms Sold' THEN month_total ELSE 0 END) AS original_rooms_sold,
+    SUM(CASE WHEN segment_name = 'Rooms Sold' THEN daily_value ELSE 0 END) 
+      - SUM(CASE WHEN segment_name = 'Rooms Sold' THEN month_total ELSE 0 END) AS adjustment
+  FROM SumCheck
+  GROUP BY property_code, segment_name, EXTRACT(YEAR FROM stay_date), EXTRACT(MONTH FROM stay_date)
+),
+FinalData AS (
+  -- Apply adjustment to the last stay_date in the month
+  SELECT 
+    sc.property_code, 
+    sc.stay_date, 
+    sc.segment_name, 
+    CASE 
+      WHEN sc.stay_date = adj.last_stay_date AND sc.segment_name = 'Rooms Sold' 
+      THEN sc.daily_value - adj.adjustment -- Adjust last date to correct any rounding errors
+      ELSE sc.daily_value 
+    END AS final_daily_value
+  FROM SumCheck sc
+  LEFT JOIN Adjustment adj
+    ON sc.property_code = adj.property_code 
+    AND sc.segment_name = adj.segment_name
+)
+-- Pivoting the segment names into columns
+SELECT 
+  property_code, 
+  stay_date, 
+
+  -- PIVOTED COLUMNS
+  SUM(CASE WHEN segment_name = 'Available Rooms' THEN final_daily_value ELSE 0 END) AS available_rms,
+  SUM(CASE WHEN segment_name = 'Contract Rooms' THEN final_daily_value ELSE 0 END) AS contract_rms,
+  SUM(CASE WHEN segment_name = 'Group Revenue' THEN final_daily_value ELSE 0 END) AS group_rev,
+  SUM(CASE WHEN segment_name = 'Group Rooms' THEN final_daily_value ELSE 0 END) AS group_rms,
+  SUM(CASE WHEN segment_name = 'Occupied Rooms' THEN final_daily_value ELSE 0 END) AS rms_occupied,
+  SUM(CASE WHEN segment_name = 'Other Rooms Revenue' THEN final_daily_value ELSE 0 END) AS other_rev,
+  SUM(CASE WHEN segment_name = 'Rooms Revenue' THEN final_daily_value ELSE 0 END) AS rev,
+  SUM(CASE WHEN segment_name = 'Rooms Sold' THEN final_daily_value ELSE 0 END) AS rms,
+  SUM(CASE WHEN segment_name = 'Transient Revenue' THEN final_daily_value ELSE 0 END) AS transient_rev,
+  SUM(CASE WHEN segment_name = 'Transient Rooms' THEN final_daily_value ELSE 0 END) AS transient_rms
+
+FROM FinalData
+GROUP BY property_code, stay_date
+ORDER BY property_code, stay_date;
+
+
+
+
+
+
+----------------------------------------------------
+-- FORECAST MAJOR SEGMENT
+----------------------------------------------------
+
+
+
+CREATE OR REPLACE VIEW `devrebel-big-query-database.Finance.Forecast_MajorSegmentDailyV` AS
+WITH RankedData AS (
+  -- Get the latest snapshot per property & segment
+  SELECT 
+    *, 
+    ROW_NUMBER() OVER (PARTITION BY property_code, segment_name ORDER BY snapshot_date DESC) AS rn
+  FROM `devrebel-big-query-database.Finance.Finance_Forecast`
+  WHERE segment_name IN ( 'Transient Rooms', 'Transient Revenue', 'Group Rooms', 
+                          'Group Revenue', 'Contract Rooms', 'Contract Revenue', 
+                          'Available Rooms', 'Rooms Sold', 'Occupied Rooms', 
+                          'Rooms Revenue', 'Other Rooms Revenue' )
+), 
+FilteredData AS (
+  -- Keep only the latest snapshot per property and segment
+  SELECT * FROM RankedData WHERE rn = 1
+), 
+Unpivoted AS (
+  -- Convert month columns into a row-based format
+  SELECT 
+    property_code,
+    segment_name,
+    CAST(SUBSTR(finance_period, 3, 2) AS INT64) + 2000 AS fiscal_year,
+    CASE 
+      WHEN month = 'month_01' THEN 1 
+      WHEN month = 'month_02' THEN 2 
+      WHEN month = 'month_03' THEN 3 
+      WHEN month = 'month_04' THEN 4 
+      WHEN month = 'month_05' THEN 5 
+      WHEN month = 'month_06' THEN 6 
+      WHEN month = 'month_07' THEN 7 
+      WHEN month = 'month_08' THEN 8 
+      WHEN month = 'month_09' THEN 9 
+      WHEN month = 'month_10' THEN 10 
+      WHEN month = 'month_11' THEN 11 
+      WHEN month = 'month_12' THEN 12 
+    END AS month_number,
+    value AS month_total
+  FROM FilteredData
+  UNPIVOT (
+    value FOR month IN (
+      month_01, month_02, month_03, month_04, month_05, month_06, 
+      month_07, month_08, month_09, month_10, month_11, month_12
+    )
+  )
+),
+DaysInMonth AS (
+  -- Assign correct number of days per month
+  SELECT 
+    *,
+    CASE 
+      WHEN month_number IN (1, 3, 5, 7, 8, 10, 12) THEN 31
+      WHEN month_number IN (4, 6, 9, 11) THEN 30
+      WHEN month_number = 2 THEN 28
+    END AS days_in_month
+  FROM Unpivoted
+),
+DailyBreakdown AS (
+  -- Distribute values evenly across all days in the month
+  SELECT 
+    property_code,
+    segment_name,
+    fiscal_year,
+    month_number,
+    month_total,
+    days_in_month,
+    DATE(fiscal_year, month_number, day_offset + 1) AS stay_date,
+    CASE 
+      WHEN segment_name IN ('Rooms Sold', 'Group Rooms', 'Transient Rooms')
+      THEN SAFE_CAST(FLOOR(month_total / days_in_month) AS INT64) -- Ensure whole number distribution
+      ELSE month_total / days_in_month
+    END AS daily_value
+  FROM DaysInMonth,
+  UNNEST(GENERATE_ARRAY(0, days_in_month - 1)) AS day_offset
+),
+Adjustment AS (
+  -- Compute adjustments for multiple segments
+  SELECT 
+    property_code, 
+    segment_name,
+    fiscal_year,
+    month_number,
+    MAX(stay_date) AS last_stay_date, -- Identify the last date of each month
+    SUM(daily_value) AS allocated_total,
+    MAX(month_total) AS original_total,
+    MAX(month_total) - SUM(daily_value) AS adjustment
+  FROM DailyBreakdown
+  WHERE segment_name IN ('Rooms Sold', 'Group Rooms', 'Transient Rooms') -- Apply fix to these
+  GROUP BY property_code, segment_name, fiscal_year, month_number
+),
+FinalData AS (
+  -- Apply adjustments on the last day of the month
+  SELECT 
+    db.property_code, 
+    db.stay_date, 
+    db.segment_name, 
+    CASE 
+      WHEN db.segment_name IN ('Rooms Sold', 'Group Rooms', 'Transient Rooms')
+       AND db.stay_date = adj.last_stay_date 
+       AND db.fiscal_year = adj.fiscal_year 
+       AND db.month_number = adj.month_number
+      THEN SAFE_CAST(db.daily_value + adj.adjustment AS INT64) -- Ensure correct rounding
+      ELSE db.daily_value
+    END AS final_daily_value
+  FROM DailyBreakdown db
+  LEFT JOIN Adjustment adj
+    ON db.property_code = adj.property_code 
+    AND db.segment_name = adj.segment_name
+    AND db.fiscal_year = adj.fiscal_year
+    AND db.month_number = adj.month_number
+)
+-- Pivot segment names into columns
+SELECT 
+  property_code, 
+  stay_date, 
+
+  -- PIVOTED COLUMNS
+  SUM(CASE WHEN segment_name = 'Available Rooms' THEN final_daily_value ELSE 0 END) AS available_rms,
+  SUM(CASE WHEN segment_name = 'Contract Rooms' THEN final_daily_value ELSE 0 END) AS contract_rms,
+  SUM(CASE WHEN segment_name = 'Group Revenue' THEN final_daily_value ELSE 0 END) AS group_rev,
+  SUM(CASE WHEN segment_name = 'Group Rooms' THEN final_daily_value ELSE 0 END) AS group_rms,
+  SUM(CASE WHEN segment_name = 'Occupied Rooms' THEN final_daily_value ELSE 0 END) AS rms_occupied,
+  SUM(CASE WHEN segment_name = 'Other Rooms Revenue' THEN final_daily_value ELSE 0 END) AS other_rev,
+  SUM(CASE WHEN segment_name = 'Rooms Revenue' THEN final_daily_value ELSE 0 END) AS rev,
+  SUM(CASE WHEN segment_name = 'Rooms Sold' THEN final_daily_value ELSE 0 END) AS rms,
+  SUM(CASE WHEN segment_name = 'Transient Revenue' THEN final_daily_value ELSE 0 END) AS transient_rev,
+  SUM(CASE WHEN segment_name = 'Transient Rooms' THEN final_daily_value ELSE 0 END) AS transient_rms
+
+FROM FinalData
+GROUP BY property_code, stay_date
+ORDER BY property_code, stay_date;
+
+
+
+

--- a/SQL-Queries/Pace Pace_Segment _TransientV _GroupV.sql
+++ b/SQL-Queries/Pace Pace_Segment _TransientV _GroupV.sql
@@ -1,0 +1,100 @@
+
+
+----------------------------------------------------
+-- CREATE Pace_Segment View Transient + Group
+----------------------------------------------------
+
+
+----------------------------------------------------
+-- TRANSIENT
+----------------------------------------------------
+
+
+CREATE OR REPLACE VIEW `devrebel-big-query-database.Pace.Pace_SegmentTransientV` AS
+WITH max_snapshot AS (
+  SELECT
+    property_code,
+    MAX(snapshot_date) AS max_snapshot_date
+  FROM `devrebel-big-query-database.Pace.Pace_Segment`
+  WHERE segment_group = "Transient"
+  GROUP BY property_code
+),
+filtered_data AS (
+  SELECT *
+  FROM `devrebel-big-query-database.Pace.Pace_Segment`
+  WHERE segment_group = "Transient"
+),
+PropertyCapacity AS (
+  SELECT
+    property_code,
+    stay_date,
+    MAX(physical_capacity) AS physical_capacity
+  FROM `devrebel-big-query-database.Pace.Pace_Property`
+  GROUP BY property_code, stay_date
+)
+
+SELECT
+  f.*,
+  p.physical_capacity
+FROM filtered_data f
+JOIN max_snapshot m
+  ON f.property_code = m.property_code
+  AND f.snapshot_date = m.max_snapshot_date
+LEFT JOIN PropertyCapacity p
+  ON f.property_code = p.property_code
+  AND f.stay_date = p.stay_date;
+  
+--WHERE f.stay_date BETWEEN "2025-03-01" AND "2025-03-31"
+--  AND f.property_code = "DTWDFH";
+
+--SELECT DISTINCT segment
+--FROM `devrebel-big-query-database.Pace.Pace_Segment`
+--ORDER BY segment
+
+
+
+----------------------------------------------------
+-- GROUP
+----------------------------------------------------
+
+
+CREATE OR REPLACE VIEW `devrebel-big-query-database.Pace.Pace_SegmentGroupV` AS
+WITH max_snapshot AS (
+  SELECT
+    property_code,
+    MAX(snapshot_date) AS max_snapshot_date
+  FROM `devrebel-big-query-database.Pace.Pace_Segment`
+  WHERE segment_group = "Group"
+  GROUP BY property_code
+),
+filtered_data AS (
+  SELECT *
+  FROM `devrebel-big-query-database.Pace.Pace_Segment`
+  WHERE segment_group = "Group"
+),
+PropertyCapacity AS (
+  SELECT
+    property_code,
+    stay_date,
+    MAX(physical_capacity) AS physical_capacity
+  FROM `devrebel-big-query-database.Pace.Pace_Property`
+  GROUP BY property_code, stay_date
+)
+
+SELECT
+  f.*,
+  p.physical_capacity
+FROM filtered_data f
+JOIN max_snapshot m
+  ON f.property_code = m.property_code
+  AND f.snapshot_date = m.max_snapshot_date
+LEFT JOIN PropertyCapacity p
+  ON f.property_code = p.property_code
+  AND f.stay_date = p.stay_date;
+  
+--WHERE f.stay_date BETWEEN "2025-03-01" AND "2025-03-31"
+--  AND f.property_code = "DTWDFH";
+
+--SELECT DISTINCT segment
+--FROM `devrebel-big-query-database.Pace.PaceData_Segment`
+--ORDER BY segment

--- a/SQL-Queries/Pace_Property 1d 3d, 7d, 14d, 21d, 30d, 60d, 90d, 120d.sql
+++ b/SQL-Queries/Pace_Property 1d 3d, 7d, 14d, 21d, 30d, 60d, 90d, 120d.sql
@@ -1,0 +1,32 @@
+
+CREATE OR REPLACE VIEW `devrebel-big-query-database.Pace.Pace_PropertyV` AS
+SELECT *
+FROM (
+  SELECT *,
+         ROW_NUMBER() OVER (PARTITION BY stay_date, property_code ORDER BY snapshot_date DESC) AS rn
+  FROM `devrebel-big-query-database.Pace.Pace_Property`
+)
+WHERE rn = 1;
+
+
+
+CREATE OR REPLACE VIEW `devrebel-big-query-database.Pace.Pace_SegmentV` AS
+SELECT *
+FROM `devrebel-big-query-database.Pace.Pace_Segment` p
+WHERE snapshot_date = (
+  SELECT MAX(snapshot_date)
+  FROM `devrebel-big-query-database.Pace.Pace_Segment` sub
+  WHERE sub.property_code = p.property_code
+);
+
+
+
+CREATE OR REPLACE VIEW `devrebel-big-query-database.Pace.Pace_RoomTypeV` AS
+SELECT *
+FROM `devrebel-big-query-database.Pace.Pace_RoomType` p
+WHERE snapshot_date = (
+  SELECT MAX(snapshot_date)
+  FROM `devrebel-big-query-database.Pace.Pace_RoomType` sub
+  WHERE sub.property_code = p.property_code
+);
+

--- a/SQL-Queries/Pace_Property CombinedReachV + CombinedReachTotalsV.sql
+++ b/SQL-Queries/Pace_Property CombinedReachV + CombinedReachTotalsV.sql
@@ -1,0 +1,221 @@
+
+
+
+----------------------------------------------------
+-- CREATE Combined Reach + Combined Reach TOtals
+----------------------------------------------------
+
+
+----------------------------------------------------
+-- COMBINED REACH
+----------------------------------------------------
+
+
+CREATE OR REPLACE VIEW `devrebel-big-query-database.Pace.CombinedReachV` AS
+WITH LatestPaceData AS (
+  SELECT
+    property_code,
+    stay_date,
+    rev,
+    rms,
+    rev_py,
+    rms_py,
+    rms_stly,
+    rev_stly,
+    rms_st2y,
+    rev_st2y,
+    physical_capacity,
+    physical_capacity_py,
+    ROW_NUMBER() OVER (
+      PARTITION BY property_code, stay_date 
+      ORDER BY snapshot_date DESC
+    ) AS rn
+  FROM `devrebel-big-query-database.Pace.Pace_Property`
+),
+
+-- Forecast Base
+Forecast AS (
+  SELECT
+    f.property_code,
+    f.stay_date,
+    f.rev_otb AS fct_rev,
+    f.available_rms AS fct_available_rms,
+    f.rms_sold AS fct_rms
+  FROM `devrebel-big-query-database.Finance.Forecast_MajorSegmentDailyV` f
+),
+
+-- Budget Base
+Budget AS (
+  SELECT
+    f.property_code,
+    f.stay_date,
+    f.rev_otb AS bgt_rev,
+    f.available_rms AS bgt_available_rms,
+    f.rms_sold AS bgt_rms
+  FROM `devrebel-big-query-database.Finance.Budget_MajorSegmentDailyV` f
+),
+
+-- Latest OTB snapshot
+OTB AS (
+  SELECT
+    property_code,
+    stay_date,
+    rev AS rev,
+    rms AS rms,
+    rev_py AS rev_py,
+    rms_py AS rms_py,
+    rms_stly AS rms_stly,
+    rev_stly AS rev_stly,
+    rms_st2y AS rms_st2y,
+    rev_st2y AS rev_st2y,
+    physical_capacity,
+    physical_capacity_py
+  FROM LatestPaceData
+  WHERE rn = 1
+)
+
+-- Combine all sources
+SELECT
+  COALESCE(f.property_code, b.property_code, o.property_code) AS property_code,
+  COALESCE(f.stay_date, b.stay_date, o.stay_date) AS stay_date,
+
+  -- Forecast metrics
+  f.fct_rev,
+  f.fct_available_rms,
+  f.fct_rms,
+
+  -- Budget metrics
+  b.bgt_rev,
+  b.bgt_available_rms,
+  b.bgt_rms,
+
+  -- OTB metrics
+  o.rev,
+  o.rms,
+  o.rev_py,
+  o.rms_py,
+  o.rms_stly,
+  o.rev_stly,
+  o.rms_st2y,
+  o.rev_st2y,
+
+  -- Physical capacity
+  o.physical_capacity,
+  o.physical_capacity_py
+
+FROM Forecast f
+FULL OUTER JOIN Budget b
+  ON f.property_code = b.property_code AND f.stay_date = b.stay_date
+FULL OUTER JOIN OTB o
+  ON COALESCE(f.property_code, b.property_code) = o.property_code
+  AND COALESCE(f.stay_date, b.stay_date) = o.stay_date;
+
+
+----------------------------------------------------
+-- COMBINED REACH TOTALS
+----------------------------------------------------
+
+
+CREATE OR REPLACE VIEW `devrebel-big-query-database.Pace.CombinedReachTotalsV` AS
+WITH base_data AS (
+  SELECT
+    FORMAT('%d-Q%d', EXTRACT(YEAR FROM stay_date), EXTRACT(QUARTER FROM stay_date)) AS period_label,
+    EXTRACT(YEAR FROM stay_date) AS stay_year,
+    stay_date,
+    property_code,
+
+    SUM(rms) AS rms,
+    SUM(rms_py) AS rms_py,
+    SUM(ms_stly) AS rms_stly,
+    SUM(rms_st2y) AS rms_st2y,
+    SUM(bgt_rms) AS bgt_rms,
+    SUM(fct_rms) AS fct_rms,
+
+    SUM(rev) AS rev,
+    SUM(rev_py) AS rev_py,
+    SUM(rev_stly) AS rev_stly,
+    SUM(rev_st2y) AS rev_st2y,
+    SUM(bgt_rev) AS bgt_rev,
+    SUM(fct_rev) AS fct_rev,
+
+    SUM(bgt_available_rms) AS bgt_available_rms,
+    SUM(fct_available_rms) AS fct_available_rms,
+
+    SUM(physical_capacity) AS physical_capacity,
+    SUM(physical_capacity_py) AS physical_capacity_py
+  FROM `devrebel-big-query-database.Pace.CombinedReachV`
+  WHERE stay_date IS NOT NULL
+    AND property_code IS NOT NULL
+  GROUP BY period_label, stay_year, stay_date, property_code
+),
+
+quarterly_data AS (
+  SELECT * EXCEPT(stay_year) FROM base_data
+),
+
+annual_data AS (
+  SELECT
+    FORMAT('%d-TOTAL', stay_year) AS period_label,
+    CAST(NULL AS DATE) AS stay_date,
+    CAST(NULL AS STRING) AS property_code,
+
+    SUM(rms) AS rms,
+    SUM(rms_py) AS rms_py,
+    SUM(rms_stly) AS rms_stly,
+    SUM(rms_st2y) AS rms_st2y,
+    SUM(bgt_rms) AS bgt_rms,
+    SUM(fct_rms) AS fct_rms,
+
+    SUM(rev) AS rev,
+    SUM(rev_py) AS rev_py,
+    SUM(rev_stly) AS rev_stly,
+    SUM(rev_st2y) AS rev_st2y,
+    SUM(bgt_rev) AS bgt_rev,
+    SUM(fct_rev) AS fct_rev,
+
+    SUM(bgt_available_rms) AS bdt_available_rms,
+    SUM(fct_available_rms) AS fct_available_rms,
+
+    SUM(physical_capacity) AS physical_capacity,
+    SUM(physical_capacity_py) AS physical_capacity_py
+  FROM base_data
+  GROUP BY stay_year
+),
+
+grand_total AS (
+  SELECT
+    'TOTAL' AS period_label,
+    CAST(NULL AS DATE) AS stay_date,
+    CAST(NULL AS STRING) AS property_code,
+
+    SUM(rms),
+    SUM(rms_py),
+    SUM(rms_stly),
+    SUM(rms_st2y),
+    SUM(bgt_rms),
+    SUM(fct_rms),
+
+    SUM(rev),
+    SUM(rev_py),
+    SUM(rev_stly),
+    SUM(rev_st2y),
+    SUM(bgt_rev),
+    SUM(fct_rev),
+
+    SUM(bgt_available_rms),
+    SUM(fct_available_rms),
+
+    SUM(physical_capacity),
+    SUM(physical_capacity_py)
+  FROM base_data
+)
+
+-- UNION of all views
+SELECT * FROM quarterly_data
+UNION ALL
+SELECT * FROM annual_data
+UNION ALL
+SELECT * FROM grand_total;
+
+
+

--- a/SQL-Queries/Pace_RoomType Pickup 1d 3d, 7d, 14d, 21d, 30d, 60d, 90d, 120d.sql
+++ b/SQL-Queries/Pace_RoomType Pickup 1d 3d, 7d, 14d, 21d, 30d, 60d, 90d, 120d.sql
@@ -1,0 +1,853 @@
+
+
+---------------------------------------
+-- CREATE 001DAY PICKUP VIEW
+---------------------------------------
+
+
+CREATE OR REPLACE VIEW
+  `aparium-dataflow.PaceData.PaceData_RoomType_001DayV` AS
+WITH
+  LatestSnapshot AS (
+  SELECT
+    property_code,
+    MAX(snapshot_date) AS latest_snapshot_date
+  FROM
+    `aparium-dataflow.PaceData.PaceData_RoomType`
+  GROUP BY
+    property_code ),
+  -- Get latest ingested_timestamp for each row on the latest snapshot date
+  FilteredLatestSnapshot AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date,roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 ),
+  CurrentSnapshot AS (
+  SELECT
+    s.property_code,
+    s.roomtype,
+    s.roomtype_sort,
+    s.roomtype_code,
+    s.roomtype_category_code,
+    s.roomtype_category,
+    s.bar,
+    s.capacity,
+    s.roomtype_physical_capacity,
+    s.stay_date,
+    s.snapshot_date,
+    s.rms,
+    s.rev,
+    s.ingested_timestamp
+  FROM
+    FilteredLatestSnapshot s
+  INNER JOIN
+    LatestSnapshot l
+  ON
+    s.property_code = l.property_code
+    AND s.snapshot_date = l.latest_snapshot_date ),
+  PriorSnapshot_1d AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date, roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 )
+SELECT
+  curr.property_code,
+  curr.roomtype,
+  curr.roomtype_sort,
+  curr.roomtype_code,
+  curr.roomtype_category_code,
+  curr.roomtype_category,
+  curr.bar,
+  curr.capacity,
+  curr.roomtype_physical_capacity,
+  curr.stay_date,
+  curr.snapshot_date AS current_snapshot_date,
+  curr.ingested_timestamp AS current_ingested_timestamp,
+  curr.rms,
+  curr.rev,
+  prior.snapshot_date AS pickup_reference_date_1d,
+  curr.rms - prior.rms AS rms_pickup_1d,
+  curr.rev - prior.rev AS rev_pickup_1d
+FROM
+  CurrentSnapshot curr
+LEFT JOIN
+  PriorSnapshot_1d prior
+ON
+  curr.property_code = prior.property_code
+  AND curr.roomtype = prior.roomtype
+  AND curr.stay_date = prior.stay_date
+  AND prior.snapshot_date = DATE_SUB(curr.snapshot_date, INTERVAL 1 DAY)
+ORDER BY
+  curr.stay_date ASC; 
+
+
+
+---------------------------------------
+-- CREATE 003DAY PICKUP VIEW
+---------------------------------------
+
+
+
+CREATE OR REPLACE VIEW
+  `aparium-dataflow.PaceData.PaceData_RoomType_003DayV` AS
+WITH
+  LatestSnapshot AS (
+  SELECT
+    property_code,
+    MAX(snapshot_date) AS latest_snapshot_date
+  FROM
+    `aparium-dataflow.PaceData.PaceData_RoomType`
+  GROUP BY
+    property_code ),
+  -- Get latest ingested_timestamp for each row on the latest snapshot date
+  FilteredLatestSnapshot AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date,roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 ),
+  CurrentSnapshot AS (
+  SELECT
+    s.property_code,
+    s.roomtype,
+    s.roomtype_sort,
+    s.roomtype_code,
+    s.roomtype_category_code,
+    s.roomtype_category,
+    s.bar,
+    s.capacity,
+    s.roomtype_physical_capacity,
+    s.stay_date,
+    s.snapshot_date,
+    s.rms,
+    s.rev,
+    s.ingested_timestamp
+  FROM
+    FilteredLatestSnapshot s
+  INNER JOIN
+    LatestSnapshot l
+  ON
+    s.property_code = l.property_code
+    AND s.snapshot_date = l.latest_snapshot_date ),
+  PriorSnapshot_3d AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date, roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 )
+SELECT
+  curr.property_code,
+  curr.roomtype,
+  curr.roomtype_sort,
+  curr.roomtype_code,
+  curr.roomtype_category_code,
+  curr.roomtype_category,
+  curr.bar,
+  curr.capacity,
+  curr.roomtype_physical_capacity,
+  curr.stay_date,
+  curr.snapshot_date AS current_snapshot_date,
+  curr.ingested_timestamp AS current_ingested_timestamp,
+  curr.rms,
+  curr.rev,
+  prior.snapshot_date AS pickup_reference_date_3d,
+  curr.rms - prior.rms AS rms_pickup_3d,
+  curr.rev - prior.rev AS rev_pickup_3d
+FROM
+  CurrentSnapshot curr
+LEFT JOIN
+  PriorSnapshot_3d prior
+ON
+  curr.property_code = prior.property_code
+  AND curr.roomtype = prior.roomtype
+  AND curr.stay_date = prior.stay_date
+  AND prior.snapshot_date = DATE_SUB(curr.snapshot_date, INTERVAL 3 DAY)
+ORDER BY
+  curr.stay_date ASC; 
+
+
+
+---------------------------------------
+-- CREATE 007DAY PICKUP VIEW
+---------------------------------------
+
+
+CREATE OR REPLACE VIEW
+  `aparium-dataflow.PaceData.PaceData_RoomType_007DayV` AS
+WITH
+  LatestSnapshot AS (
+  SELECT
+    property_code,
+    MAX(snapshot_date) AS latest_snapshot_date
+  FROM
+    `aparium-dataflow.PaceData.PaceData_RoomType`
+  GROUP BY
+    property_code ),
+  -- Get latest ingested_timestamp for each row on the latest snapshot date
+  FilteredLatestSnapshot AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date,roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 ),
+  CurrentSnapshot AS (
+  SELECT
+    s.property_code,
+    s.roomtype,
+    s.roomtype_sort,
+    s.roomtype_code,
+    s.roomtype_category_code,
+    s.roomtype_category,
+    s.bar,
+    s.capacity,
+    s.roomtype_physical_capacity,
+    s.stay_date,
+    s.snapshot_date,
+    s.rms,
+    s.rev,
+    s.ingested_timestamp
+  FROM
+    FilteredLatestSnapshot s
+  INNER JOIN
+    LatestSnapshot l
+  ON
+    s.property_code = l.property_code
+    AND s.snapshot_date = l.latest_snapshot_date ),
+  PriorSnapshot_7d AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date, roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 )
+SELECT
+  curr.property_code,
+  curr.roomtype,
+  curr.roomtype_sort,
+  curr.roomtype_code,
+  curr.roomtype_category_code,
+  curr.roomtype_category,
+  curr.bar,
+  curr.capacity,
+  curr.roomtype_physical_capacity,
+  curr.stay_date,
+  curr.snapshot_date AS current_snapshot_date,
+  curr.ingested_timestamp AS current_ingested_timestamp,
+  curr.rms,
+  curr.rev,
+  prior.snapshot_date AS pickup_reference_date_7d,
+  curr.rms - prior.rms AS rms_pickup_7d,
+  curr.rev - prior.rev AS rev_pickup_7d
+FROM
+  CurrentSnapshot curr
+LEFT JOIN
+  PriorSnapshot_7d prior
+ON
+  curr.property_code = prior.property_code
+  AND curr.roomtype = prior.roomtype
+  AND curr.stay_date = prior.stay_date
+  AND prior.snapshot_date = DATE_SUB(curr.snapshot_date, INTERVAL 7 DAY)
+ORDER BY
+  curr.stay_date ASC;
+
+
+
+---------------------------------------
+-- CREATE 0014DAY PICKUP VIEW
+---------------------------------------
+
+
+
+CREATE OR REPLACE VIEW
+  `aparium-dataflow.PaceData.PaceData_RoomType_014DayV` AS
+WITH
+  LatestSnapshot AS (
+  SELECT
+    property_code,
+    MAX(snapshot_date) AS latest_snapshot_date
+  FROM
+    `aparium-dataflow.PaceData.PaceData_RoomType`
+  GROUP BY
+    property_code ),
+  -- Get latest ingested_timestamp for each row on the latest snapshot date
+  FilteredLatestSnapshot AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date,roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 ),
+  CurrentSnapshot AS (
+  SELECT
+    s.property_code,
+    s.roomtype,
+    s.roomtype_sort,
+    s.roomtype_code,
+    s.roomtype_category_code,
+    s.roomtype_category,
+    s.bar,
+    s.capacity,
+    s.roomtype_physical_capacity,
+    s.stay_date,
+    s.snapshot_date,
+    s.rms,
+    s.rev,
+    s.ingested_timestamp
+  FROM
+    FilteredLatestSnapshot s
+  INNER JOIN
+    LatestSnapshot l
+  ON
+    s.property_code = l.property_code
+    AND s.snapshot_date = l.latest_snapshot_date ),
+  PriorSnapshot_14d AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date, roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 )
+SELECT
+  curr.property_code,
+  curr.roomtype,
+  curr.roomtype_sort,
+  curr.roomtype_code,
+  curr.roomtype_category_code,
+  curr.roomtype_category,
+  curr.bar,
+  curr.capacity,
+  curr.roomtype_physical_capacity,
+  curr.stay_date,
+  curr.snapshot_date AS current_snapshot_date,
+  curr.ingested_timestamp AS current_ingested_timestamp,
+  curr.rms,
+  curr.rev,
+  prior.snapshot_date AS pickup_reference_date_14d,
+  curr.rms - prior.rms AS rms_pickup_14d,
+  curr.rev - prior.rev AS rev_pickup_14d
+FROM
+  CurrentSnapshot curr
+LEFT JOIN
+  PriorSnapshot_14d prior
+ON
+  curr.property_code = prior.property_code
+  AND curr.roomtype = prior.roomtype
+  AND curr.stay_date = prior.stay_date
+  AND prior.snapshot_date = DATE_SUB(curr.snapshot_date, INTERVAL 14 DAY)
+ORDER BY
+  curr.stay_date ASC; 
+
+
+
+---------------------------------------
+-- CREATE 021DAY PICKUP VIEW
+---------------------------------------
+
+
+
+CREATE OR REPLACE VIEW
+  `aparium-dataflow.PaceData.PaceData_RoomType_021DayV` AS
+WITH
+  LatestSnapshot AS (
+  SELECT
+    property_code,
+    MAX(snapshot_date) AS latest_snapshot_date
+  FROM
+    `aparium-dataflow.PaceData.PaceData_RoomType`
+  GROUP BY
+    property_code ),
+  -- Get latest ingested_timestamp for each row on the latest snapshot date
+  FilteredLatestSnapshot AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date,roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 ),
+  CurrentSnapshot AS (
+  SELECT
+    s.property_code,
+    s.roomtype,
+    s.roomtype_sort,
+    s.roomtype_code,
+    s.roomtype_category_code,
+    s.roomtype_category,
+    s.bar,
+    s.capacity,
+    s.roomtype_physical_capacity,
+    s.stay_date,
+    s.snapshot_date,
+    s.rms,
+    s.rev,
+    s.ingested_timestamp
+  FROM
+    FilteredLatestSnapshot s
+  INNER JOIN
+    LatestSnapshot l
+  ON
+    s.property_code = l.property_code
+    AND s.snapshot_date = l.latest_snapshot_date ),
+  PriorSnapshot_21d AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date, roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 )
+SELECT
+  curr.property_code,
+  curr.roomtype,
+  curr.roomtype_sort,
+  curr.roomtype_code,
+  curr.roomtype_category_code,
+  curr.roomtype_category,
+  curr.bar,
+  curr.capacity,
+  curr.roomtype_physical_capacity,
+  curr.stay_date,
+  curr.snapshot_date AS current_snapshot_date,
+  curr.ingested_timestamp AS current_ingested_timestamp,
+  curr.rms,
+  curr.rev,
+  prior.snapshot_date AS pickup_reference_date_21d,
+  curr.rms - prior.rms AS rms_pickup_21d,
+  curr.rev - prior.rev AS rev_pickup_21d
+FROM
+  CurrentSnapshot curr
+LEFT JOIN
+  PriorSnapshot_21d prior
+ON
+  curr.property_code = prior.property_code
+  AND curr.roomtype = prior.roomtype
+  AND curr.stay_date = prior.stay_date
+  AND prior.snapshot_date = DATE_SUB(curr.snapshot_date, INTERVAL 21 DAY)
+ORDER BY
+  curr.stay_date ASC;
+
+
+---------------------------------------
+-- CREATE 030DAY PICKUP VIEW
+---------------------------------------
+
+
+CREATE OR REPLACE VIEW
+  `aparium-dataflow.PaceData.PaceData_RoomType_030DayV` AS
+WITH
+  LatestSnapshot AS (
+  SELECT
+    property_code,
+    MAX(snapshot_date) AS latest_snapshot_date
+  FROM
+    `aparium-dataflow.PaceData.PaceData_RoomType`
+  GROUP BY
+    property_code ),
+  -- Get latest ingested_timestamp for each row on the latest snapshot date
+  FilteredLatestSnapshot AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date,roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 ),
+  CurrentSnapshot AS (
+  SELECT
+    s.property_code,
+    s.roomtype,
+    s.roomtype_sort,
+    s.roomtype_code,
+    s.roomtype_category_code,
+    s.roomtype_category,
+    s.bar,
+    s.capacity,
+    s.roomtype_physical_capacity,
+    s.stay_date,
+    s.snapshot_date,
+    s.rms,
+    s.rev,
+    s.ingested_timestamp
+  FROM
+    FilteredLatestSnapshot s
+  INNER JOIN
+    LatestSnapshot l
+  ON
+    s.property_code = l.property_code
+    AND s.snapshot_date = l.latest_snapshot_date ),
+  PriorSnapshot_30d AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date, roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 )
+SELECT
+  curr.property_code,
+  curr.roomtype,
+  curr.roomtype_sort,
+  curr.roomtype_code,
+  curr.roomtype_category_code,
+  curr.roomtype_category,
+  curr.bar,
+  curr.capacity,
+  curr.roomtype_physical_capacity,
+  curr.stay_date,
+  curr.snapshot_date AS current_snapshot_date,
+  curr.ingested_timestamp AS current_ingested_timestamp,
+  curr.rms,
+  curr.rev,
+  prior.snapshot_date AS pickup_reference_date_30d,
+  curr.rms - prior.rms AS rms_pickup_30d,
+  curr.rev - prior.rev AS rev_pickup_30d
+FROM
+  CurrentSnapshot curr
+LEFT JOIN
+  PriorSnapshot_30d prior
+ON
+  curr.property_code = prior.property_code
+  AND curr.roomtype = prior.roomtype
+  AND curr.stay_date = prior.stay_date
+  AND prior.snapshot_date = DATE_SUB(curr.snapshot_date, INTERVAL 30 DAY)
+ORDER BY
+  curr.stay_date ASC;
+
+
+---------------------------------------
+-- CREATE 060DAY PICKUP VIEW
+---------------------------------------
+
+
+
+  CREATE OR REPLACE VIEW
+  `aparium-dataflow.PaceData.PaceData_RoomType_060DayV` AS
+WITH
+  LatestSnapshot AS (
+  SELECT
+    property_code,
+    MAX(snapshot_date) AS latest_snapshot_date
+  FROM
+    `aparium-dataflow.PaceData.PaceData_RoomType`
+  GROUP BY
+    property_code ),
+  -- Get latest ingested_timestamp for each row on the latest snapshot date
+  FilteredLatestSnapshot AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date,roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 ),
+  CurrentSnapshot AS (
+  SELECT
+    s.property_code,
+    s.roomtype,
+    s.roomtype_sort,
+    s.roomtype_code,
+    s.roomtype_category_code,
+    s.roomtype_category,
+    s.bar,
+    s.capacity,
+    s.roomtype_physical_capacity,
+    s.stay_date,
+    s.snapshot_date,
+    s.rms,
+    s.rev,
+    s.ingested_timestamp
+  FROM
+    FilteredLatestSnapshot s
+  INNER JOIN
+    LatestSnapshot l
+  ON
+    s.property_code = l.property_code
+    AND s.snapshot_date = l.latest_snapshot_date ),
+  PriorSnapshot_60d AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date, roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 )
+SELECT
+  curr.property_code,
+  curr.roomtype,
+  curr.roomtype_sort,
+  curr.roomtype_code,
+  curr.roomtype_category_code,
+  curr.roomtype_category,
+  curr.bar,
+  curr.capacity,
+  curr.roomtype_physical_capacity,
+  curr.stay_date,
+  curr.snapshot_date AS current_snapshot_date,
+  curr.ingested_timestamp AS current_ingested_timestamp,
+  curr.rms,
+  curr.rev,
+  prior.snapshot_date AS pickup_reference_date_60d,
+  curr.rms - prior.rms AS rms_pickup_60d,
+  curr.rev - prior.rev AS rev_pickup_60d
+FROM
+  CurrentSnapshot curr
+LEFT JOIN
+  PriorSnapshot_60d prior
+ON
+  curr.property_code = prior.property_code
+  AND curr.roomtype = prior.roomtype
+  AND curr.stay_date = prior.stay_date
+  AND prior.snapshot_date = DATE_SUB(curr.snapshot_date, INTERVAL 60 DAY)
+ORDER BY
+  curr.stay_date ASC;
+
+
+
+---------------------------------------
+-- CREATE 090DAY PICKUP VIEW
+---------------------------------------
+
+
+
+CREATE OR REPLACE VIEW
+  `aparium-dataflow.PaceData.PaceData_RoomType_090DayV` AS
+WITH
+  LatestSnapshot AS (
+  SELECT
+    property_code,
+    MAX(snapshot_date) AS latest_snapshot_date
+  FROM
+    `aparium-dataflow.PaceData.PaceData_RoomType`
+  GROUP BY
+    property_code ),
+  -- Get latest ingested_timestamp for each row on the latest snapshot date
+  FilteredLatestSnapshot AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date,roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 ),
+  CurrentSnapshot AS (
+  SELECT
+    s.property_code,
+    s.roomtype,
+    s.roomtype_sort,
+    s.roomtype_code,
+    s.roomtype_category_code,
+    s.roomtype_category,
+    s.bar,
+    s.capacity,
+    s.roomtype_physical_capacity,
+    s.stay_date,
+    s.snapshot_date,
+    s.rms,
+    s.rev,
+    s.ingested_timestamp
+  FROM
+    FilteredLatestSnapshot s
+  INNER JOIN
+    LatestSnapshot l
+  ON
+    s.property_code = l.property_code
+    AND s.snapshot_date = l.latest_snapshot_date ),
+  PriorSnapshot_90d AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date, roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 )
+SELECT
+  curr.property_code,
+  curr.roomtype,
+  curr.roomtype_sort,
+  curr.roomtype_code,
+  curr.roomtype_category_code,
+  curr.roomtype_category,
+  curr.bar,
+  curr.capacity,
+  curr.roomtype_physical_capacity,
+  curr.stay_date,
+  curr.snapshot_date AS current_snapshot_date,
+  curr.ingested_timestamp AS current_ingested_timestamp,
+  curr.rms,
+  curr.rev,
+  prior.snapshot_date AS pickup_reference_date_90d,
+  curr.rms - prior.rms AS rms_pickup_90d,
+  curr.rev - prior.rev AS rev_pickup_90d
+FROM
+  CurrentSnapshot curr
+LEFT JOIN
+  PriorSnapshot_90d prior
+ON
+  curr.property_code = prior.property_code
+  AND curr.roomtype = prior.roomtype
+  AND curr.stay_date = prior.stay_date
+  AND prior.snapshot_date = DATE_SUB(curr.snapshot_date, INTERVAL 90 DAY)
+ORDER BY
+  curr.stay_date ASC;
+
+
+
+---------------------------------------
+-- CREATE 120DAY PICKUP VIEW
+---------------------------------------
+
+
+
+CREATE OR REPLACE VIEW
+  `aparium-dataflow.PaceData.PaceData_RoomType120DayV` AS
+WITH
+  LatestSnapshot AS (
+  SELECT
+    property_code,
+    MAX(snapshot_date) AS latest_snapshot_date
+  FROM
+    `aparium-dataflow.PaceData.PaceData_RoomType`
+  GROUP BY
+    property_code ),
+  -- Get latest ingested_timestamp for each row on the latest snapshot date
+  FilteredLatestSnapshot AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date,roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 ),
+  CurrentSnapshot AS (
+  SELECT
+    s.property_code,
+    s.roomtype,
+    s.roomtype_sort,
+    s.roomtype_code,
+    s.roomtype_category_code,
+    s.roomtype_category,
+    s.bar,
+    s.capacity,
+    s.roomtype_physical_capacity,
+    s.stay_date,
+    s.snapshot_date,
+    s.rms,
+    s.rev,
+    s.ingested_timestamp
+  FROM
+    FilteredLatestSnapshot s
+  INNER JOIN
+    LatestSnapshot l
+  ON
+    s.property_code = l.property_code
+    AND s.snapshot_date = l.latest_snapshot_date ),
+  PriorSnapshot_120d AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY property_code, snapshot_date, roomtype, stay_date ORDER BY ingested_timestamp DESC ) AS rn
+    FROM
+      `aparium-dataflow.PaceData.PaceData_RoomType` )
+  WHERE
+    rn = 1 )
+SELECT
+  curr.property_code,
+  curr.roomtype,
+  curr.roomtype_sort,
+  curr.roomtype_code,
+  curr.roomtype_category_code,
+  curr.roomtype_category,
+  curr.bar,
+  curr.capacity,
+  curr.roomtype_physical_capacity,
+  curr.stay_date,
+  curr.snapshot_date AS current_snapshot_date,
+  curr.ingested_timestamp AS current_ingested_timestamp,
+  curr.rms,
+  curr.rev,
+  prior.snapshot_date AS pickup_reference_date_120d,
+  curr.rms - prior.rms AS rms_pickup_120d,
+  curr.rev - prior.rev AS rev_pickup_120d
+FROM
+  CurrentSnapshot curr
+LEFT JOIN
+  PriorSnapshot_120d prior
+ON
+  curr.property_code = prior.property_code
+  AND curr.roomtype = prior.roomtype
+  AND curr.stay_date = prior.stay_date
+  AND prior.snapshot_date = DATE_SUB(curr.snapshot_date, INTERVAL 120 DAY)
+ORDER BY
+  curr.stay_date ASC;
+
+
+
+


### PR DESCRIPTION
## Summary by Sourcery

Add a suite of base SQL view definitions to support pickup metrics, daily financial segmentation, combined reach reporting, and snapshot views for pace and demand data.

New Features:
- Add pickup calculation views for PaceData_RoomType at 1, 3, 7, 14, 21, 30, 60, 90, and 120-day intervals
- Create Budget_MajorSegmentDailyV and Forecast_MajorSegmentDailyV views to unpivot monthly finance data into daily segment breakdowns with rounding adjustments
- Introduce CombinedReachV and CombinedReachTotalsV views to merge forecast, budget, and on-the-books pace metrics and provide quarterly, annual, and grand total aggregations
- Add Pace segment and property snapshot views (Transient, Group, RoomType, SegmentV, PropertyV) selecting the latest snapshot per entity
- Add DemandData snapshot views for Property, Segment, and Channel tables to expose only the latest daily data