### PR TITLE
Added Pace Segment Views

### DIFF
--- a/SQL-Queries/Pace_Segment Views.sql
+++ b/SQL-Queries/Pace_Segment Views.sql
@@ -1,0 +1,49 @@
+-- ----------------------------------------------------------------
+-- MATERIALIZED VIEW: PaceData_SegmentFilteredRecordMV
+-- ----------------------------------------------------------------
+-- Identifies the latest ingested_timestamp for each snapshot record 
+-- grouped by property_code, segment, stay_date, and snapshot_date
+
+CREATE OR REPLACE MATERIALIZED VIEW `devrebel-big-query-database.Pace.Pace_SegmentFilteredRecordMV`
+AS
+SELECT
+  property_code,
+  segment,
+  stay_date,
+  snapshot_date,
+  MAX(ingested_timestamp) AS latest_ingested_timestamp
+FROM `devrebel-big-query-database.Pace.Pace_Segment`
+GROUP BY property_code, segment, stay_date, snapshot_date;
+
+
+
+-- ----------------------------------------------------------------
+-- VIEW: PaceData_SegmentV
+-- ----------------------------------------------------------------
+-- Expands filtered materialized view by joining back to the full table,
+-- restoring all columns but keeping only the most recently ingested rows per snapshot
+
+CREATE OR REPLACE VIEW `devrebel-big-query-database.Pace.Pace_SegmentV` AS
+SELECT s.*
+FROM `devrebel-big-query-database.Pace.Pace_Segment` AS s
+JOIN `devrebel-big-query-database.Pace.Pace_SegmentFilteredRecordMV` AS mv
+  ON s.property_code = mv.property_code
+ AND s.segment = mv.segment
+ AND s.stay_date = mv.stay_date
+ AND s.snapshot_date = mv.snapshot_date
+ AND s.ingested_timestamp = mv.latest_ingested_timestamp;
+
+
+
+-- ----------------------------------------------------------------
+-- VIEW: PaceData_SegmentV_LatestSnapshotV
+-- ----------------------------------------------------------------
+-- Returns only the latest snapshot_date per stay_date and property_code
+
+CREATE OR REPLACE VIEW `devrebel-big-query-database.Pace.Pace_SegmentV_LatestSnapshotV` AS
+SELECT *
+FROM `devrebel-big-query-database.Pace.Pace_SegmentV`
+QUALIFY ROW_NUMBER() OVER (
+  PARTITION BY stay_date, property_code
+  ORDER BY snapshot_date DESC
+) = 1;


### PR DESCRIPTION
## Summary by Sourcery

Add materialized and standard BigQuery views to filter and retrieve the latest Pace segment records and snapshots per property and stay date.

New Features:
- Introduce Pace_SegmentFilteredRecordMV materialized view to capture the latest ingested timestamp for each property, segment, stay date, and snapshot date grouping
- Create Pace_SegmentV view to join filtered results back to the full Pace_Segment table and restore all columns for the most recently ingested records
- Define Pace_SegmentV_LatestSnapshotV view to return only the latest snapshot per stay date and property code