### PR TITLE
Dev

### DIFF
--- a/SQL-Queries/Create Pace_RoomType Views.sql
+++ b/SQL-Queries/Create Pace_RoomType Views.sql
@@ -44,7 +44,7 @@ CREATE OR REPLACE VIEW `devrebel-big-query-database.Pace.Pace_RoomTypeV_LatestSn
 SELECT *
 FROM `devrebel-big-query-database.Pace.Pace_RoomTypeV`
 QUALIFY ROW_NUMBER() OVER (
-  PARTITION BY stay_date, property_code
+  PARTITION BY stay_date, property_code, roomtype
   ORDER BY snapshot_date DESC
 ) = 1;
 

--- a/SQL-Queries/Create Pace_Segment Views.sql
+++ b/SQL-Queries/Create Pace_Segment Views.sql
@@ -44,7 +44,7 @@ CREATE OR REPLACE VIEW `devrebel-big-query-database.Pace.Pace_SegmentV_LatestSna
 SELECT *
 FROM `devrebel-big-query-database.Pace.Pace_SegmentV`
 QUALIFY ROW_NUMBER() OVER (
-  PARTITION BY stay_date, property_code
+  PARTITION BY stay_date, property_code, segment
   ORDER BY snapshot_date DESC
 ) = 1;
 


### PR DESCRIPTION
## Summary by Sourcery

Correct the latest-snapshot views by adding the missing dimension to their partitioning logic.

Bug Fixes:
- Include roomtype in the PARTITION BY clause for the Pace_RoomType latest-snapshot view
- Include segment in the PARTITION BY clause for the Pace_Segment latest-snapshot view