### PR TITLE
add metadata_extract.sql

### DIFF
--- a/queries/table_utilities/metadata_extract.sql
+++ b/queries/table_utilities/metadata_extract.sql
@@ -1,0 +1,11 @@
+SELECT 
+  table_schema, 
+  table_name, 
+  column_name, 
+  description -- This identifies which ones have meta-descriptions
+FROM 
+  `devrebel-big-query-database`.`region-us-central1`.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS
+WHERE 
+  table_schema IN ('dev_hotel_analytics', 'dev_hotel_costar', 'dev_hotel_forecast', 'dev_hotel_g4a', 'dev_hotel_sales', 'dev_hotel_settings', 'devrebel')
+ORDER BY 
+  column_name;


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce metadata_extract.sql to list column descriptions for specified schemas from BigQuery INFORMATION_SCHEMA.